### PR TITLE
Update APPEmailComposer.m

### DIFF
--- a/src/ios/APPEmailComposer.m
+++ b/src/ios/APPEmailComposer.m
@@ -259,7 +259,10 @@
             NSString* pathExt  = [basename pathExtension];
             NSString* fileName = [basename pathComponents].lastObject;
             NSString* mimeType = [self getMimeTypeFromFileExtension:pathExt];
-
+            
+            // Couldn't find mimeType, must be some type of binary data
+            if (mimeType == nil) mimeType = @"application/octet-stream";
+            
             [draft addAttachmentData:data mimeType:mimeType fileName:fileName];
         }
     }


### PR DESCRIPTION
Fixed a bug in iOS. When an attachment is added for which no known mime extension exists (like a proprietary binary format), getMimeTypeFromFileExtension returns nil, which according to https://developer.apple.com/library/prerelease/ios/documentation/MessageUI/Reference/MFMailComposeViewController_class/index.html#//apple_ref/occ/instm/MFMailComposeViewController/addAttachmentData:mimeType:fileName: should never be passed as such to addAttachmentData (it causes the e-mail composition app to append the content of the file to the body, causing some unexpected behavior in e-mail clients reading the e-mail). This patch sets a failback content type of "application/octet-stream" which is recommended for binary files by RFC2046.
